### PR TITLE
No browser event when property gets updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -463,8 +463,7 @@
     "@angular/flex-layout": {
       "version": "9.0.0-beta.31",
       "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-9.0.0-beta.31.tgz",
-      "integrity": "sha512-g94u2mecDl87ORvFRuOBshV/S/ETE4bybClU2e1xXKWNG+rhRHchChneHSonc29ZLyROTjHhmAtKOYojL92uLA==",
-      "dev": true
+      "integrity": "sha512-g94u2mecDl87ORvFRuOBshV/S/ETE4bybClU2e1xXKWNG+rhRHchChneHSonc29ZLyROTjHhmAtKOYojL92uLA=="
     },
     "@angular/forms": {
       "version": "9.1.12",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.901.12",
     "@angular/cli": "~9.1.12",
-    "@angular/cdk": "9.1.2",
     "@angular/compiler-cli": "~9.1.12",
     "@electron-forge/cli": "^6.0.0-beta.52",
     "@electron-forge/maker-deb": "^6.0.0-beta.52",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, NgZone } from '@angular/core';
 import { NotesNodeImp } from './utils/notes-node';
 import { ResizeEvent } from 'angular-resizable-element';
-import { ElectronService } from './service/electron.service';
+import { ElectronServiceFile } from './service/electron.service.files';
 import { SelectedNodeService } from './service/selected-node.service';
 
 @Component({
@@ -13,54 +13,31 @@ export class AppComponent implements OnInit{
   title = 'myLifeNotes';
   public style: object = {};
   isSelected:boolean=false;
-  NOTES_DATA: NotesNodeImp[]=[];/* = 
-  [
-    {
-      name: 'Fruit',
-      level:1,
-      children: [
-        {name: 'Apple', level:2},
-        {name: 'Banana', level:2 },
-        {name: 'Fruit loops', level:2},
-      ]
-    }, {
-      name: 'Vegetables', level:1,
-      children: [
-        {
-          name: 'Green', level:2, 
-          children: [
-            {name: 'Broccoli', level:3 },
-            {name: 'Brussels sprouts', level:3},
-          ]
-        }, {
-          name: 'Orange', level:2, 
-          children: [
-            {name: 'Pumpkins', level:3},
-            {name: 'Carrots', level:3},
-          ]
-        },
-      ]
-    },
-  ];*/
+  NOTES_DATA: NotesNodeImp[]=[];
   
   ngOnInit(){
     this.electron_service.notes.subscribe( notes =>{
       console.log("app.component notes ", notes);
+      let tmp = [];
       notes.forEach( note => {
         let name_parts = note.split('-'); 
         let notesObj =new NotesNodeImp(Number.parseInt(name_parts[0]));
         notesObj.name = note;
         notesObj.label = name_parts[1];
-        this.NOTES_DATA.push(notesObj);
-        this.NOTES_DATA = Object.assign([], this.NOTES_DATA);
+        tmp.push(notesObj);
       });
+      this.NOTES_DATA = Object.assign([], tmp);
+      this.zone.run(() => this.NOTES_DATA = Object.assign([], tmp));
+      console.log("app.component this.NOTES_DATA ", this.NOTES_DATA);
     })
     this.select_service.currentNode.subscribe(node => this.isSelected = node!=null)
   }
 
 
-  constructor(private electron_service: ElectronService,
-              private select_service: SelectedNodeService){
+  constructor(private electron_service: ElectronServiceFile,
+              private select_service: SelectedNodeService,
+              public zone: NgZone){
+    this.electron_service.loadFiles();
     
   }
   

--- a/src/app/component/data/data.component.ts
+++ b/src/app/component/data/data.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { EditorChangeContent, EditorChangeSelection } from 'ngx-quill'
 import Quill from 'quill'
-import { ElectronService } from '../../service/electron.service';
+import { ElectronService } from '../../service/electron.service.data';
 import { SelectedNodeService } from '../../service/selected-node.service';
 import { interval, Subscription } from 'rxjs';
 
@@ -37,9 +37,6 @@ export class NotesDataComponent implements OnInit {
           setTimeout(() => {
           (<HTMLInputElement>document.getElementById("note_editor")).focus();
           }, 0);
-          //let editor_container = <HTMLInputElement>document.getElementById("note_editor");
-          //this.editor = new Quill(editor_container);
-          //console.log("editor " , editor)
           this.data = data;
           if( this.editor){
             this.updateData();
@@ -81,10 +78,9 @@ export class NotesDataComponent implements OnInit {
 
   changedEditor($event: EditorChangeContent | EditorChangeSelection) {
     // tslint:disable-next-line:no-console
-    console.log('editor-change', $event)
-    console.log('editor ', this.editor.getContents());
+    //console.log('editor-change', $event)
+    //console.log('editor ', this.editor.getContents());
     this.data = this.editor.getContents();
-    //this.os_service.saveData(this.note_name, this.editor.getContents());
     this.changed = true;
   }
 

--- a/src/app/component/navigation/navigation.component.ts
+++ b/src/app/component/navigation/navigation.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit, ViewEncapsulation, Input } from '@angular/core';
 import { NotesActionService } from "../../service/notes-action.service";
-import { NotesTreeDataSource } from './navigation-datasource';
 import { SelectedNodeService } from '../../service/selected-node.service';
 import { NotesNodeImp } from '../../utils/notes-node';
-import { ElectronService } from '../../service/electron.service';
+import { ElectronService } from '../../service/electron.service.data';
 
 @Component({
   selector: 'app-navigation',
@@ -17,19 +16,17 @@ export class NotesTreeComponent implements OnInit {
   new_node_name: string = '';
   node_selected: NotesNodeImp;
   data: NotesNodeImp[]=[];
-  @Input() 
+
+  @Input('data_saved') 
   set data_saved (d: NotesNodeImp[]){
     console.log("data1 " , d)
     this.data = d;
-  }// = [new NotesNodeImp(1)];
-  dataSource: NotesTreeDataSource;
-
+  }
 
 
   constructor(private action_service: NotesActionService,
     private select_service: SelectedNodeService,
     private os_service: ElectronService) {
-    this.dataSource = new NotesTreeDataSource();
   }
 
   ngOnInit() {

--- a/src/app/component/toolbar/toolbar.component.ts
+++ b/src/app/component/toolbar/toolbar.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { ElectronService } from '../../service/electron.service';
 import { NotesActionService } from "../../service/notes-action.service";
 
 @Component({
@@ -12,8 +11,7 @@ export class ToolbarComponent implements OnInit {
 
   message:string='';
 
-  constructor( private electron_service: ElectronService,
-               private action_service: NotesActionService) { }
+  constructor( private action_service: NotesActionService) { }
 
   ngOnInit(): void {
     this.action_service.currentMessage.subscribe(message => this.message = message)

--- a/src/app/service/electron.service.data.ts
+++ b/src/app/service/electron.service.data.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { IpcRenderer } from 'electron';
+import { NotesNodeImp } from '../utils/notes-node'
 
 
 @Injectable({
@@ -22,30 +23,13 @@ export class ElectronService {
     } else {
       console.warn('App not running inside Electron!');
     }
-    // //electron.ipcRenderer
-    // this.ipc.on('getImagesResponse', (event, images) => {
-    //   this.images.next(images);
-    // });
-    // //electron.ipcRenderer
-    // this.ipc.on('getDirectoryResponse', (event, directory) => {
-    //   this.directory.next(directory);
-    // });
-    this.ipc.send('loadNotes');
-    
-    this.ipc.on('getNotesResponse', (event, note) => {
-      this.notes.next(note);
-      console.log("available notes ", note);
-    });
     
     this.ipc.on('getNoteDataResponse', (event, data) => {
-      console.log("available notes ", data);
       this.data.next(data);
-      console.log("available notes ", data);
     });
   }
 
   getNote(note_name:string) {
-    //electron.ipcRenderer
     this.ipc.send('openNotes', note_name);
   }
 

--- a/src/app/service/electron.service.files.ts
+++ b/src/app/service/electron.service.files.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { IpcRenderer } from 'electron';
+import { NotesNodeImp } from '../utils/notes-node'
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ElectronServiceFile {
+
+  private ipc: IpcRenderer
+  notes = new BehaviorSubject<string[]>([]);
+  data = new BehaviorSubject<any>({});
+
+  constructor() {
+    if ((<any>window).require) {
+      try {
+        this.ipc = (<any>window).require('electron').ipcRenderer;
+      } catch (e) {
+        throw e;
+      }
+    } else {
+      console.warn('App not running inside Electron!');
+    }
+    
+    this.ipc.on('getNotesResponse', (event, notes) => {
+      console.log("available notes ", notes);
+      this.notes.next(notes);
+    });
+    
+  }
+
+  loadFiles(){
+    console.log('load files: ');
+    this.ipc.send('loadNotes');
+  }
+
+}

--- a/src/app/service/electron.service.spec.ts
+++ b/src/app/service/electron.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ElectronService } from './electron.service';
+import { ElectronService } from './electron.service.files';
 
 describe('ElectronService', () => {
   let service: ElectronService;


### PR DESCRIPTION
The browser (in this case Electron) is not generating an event when a property gets updated. Therefore, the data-driven components don't do anything until an action forces the event. The solution is to tell Angular that a property has been updated and that it needs to check the DOM for affected components.